### PR TITLE
mapStoreToConfig is not always passed the newest state.

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -169,11 +169,10 @@ function connect(mapStoreStateToConfig, mapDispatchToConfig, mergeConfig, option
 				var storeState = this.getStore().getState();
 				var prevStoreConfig = this.storeConfig_;
 				var storeConfig = this.getStoreConfig_(storeState);
-				if (object.shallowEqual(prevStoreConfig, storeConfig)) {
-					return;
-				}
-				this.hasStoreConfigChanged_ = true;
 				this.storeState = storeState;
+				if (!object.shallowEqual(prevStoreConfig, storeConfig)) {
+					this.hasStoreConfigChanged_ = true;
+				}
 			}
 
 			/**


### PR DESCRIPTION
I noticed that my mapStoreToConfig seemed to be getting an older state.

It looks like `handleStoreChange_` was not updating it's `storeState` if the config returned by `mapStoreToConfig` was the same. This meant that if the component was re-rendered later, by being passed a new prop, it's `mapStoreToConfig` would be passed an older state.

Let me know if this makes sense.